### PR TITLE
Fix for ghc-7.10 and change maintainer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: haskell
+
+env:
+  - GHCVER=7.6.3
+  - GHCVER=7.8.4
+  - GHCVER=7.10.1
+
+before_install:
+  - sudo add-apt-repository -y ppa:hvr/ghc
+  - sudo apt-get update
+  - sudo apt-get install ghc-$GHCVER
+  - export PATH=/opt/ghc/$GHCVER/bin:$PATH
+  - sudo apt-get install cabal-install-1.22
+  - export PATH=/opt/cabal/1.22/bin:$PATH
+  - ghc --version
+  - cabal --version
+
+script:
+  - cabal configure --enable-tests --ghc-options='-Wall' && cabal build && cabal test
+  - cabal install --ghc-options='-Wall'

--- a/Data/Graph/Wrapper.hs
+++ b/Data/Graph/Wrapper.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 -- | A wrapper around the types and functions from "Data.Graph" to make programming with them less painful. Also
 -- implements some extra useful goodies such as 'successors' and 'sccGraph', and improves the documentation of
 -- the behaviour of some functions.

--- a/graph-wrapper.cabal
+++ b/graph-wrapper.cabal
@@ -1,7 +1,7 @@
 Cabal-Version:      >= 1.6
 Build-Type:         Simple
 Name:               graph-wrapper
-Version:            0.2.4.3
+Version:            0.2.4.4
 Maintainer:         Max Bolingbroke <batterseapower@hotmail.com>, Sönke Hahn <soenkehahn@gmail.com>
 Homepage:           https://github.com/soenkehahn/graph-wrapper
 License:            BSD3

--- a/graph-wrapper.cabal
+++ b/graph-wrapper.cabal
@@ -1,14 +1,18 @@
-Cabal-Version:      >= 1.2
+Cabal-Version:      >= 1.6
 Build-Type:         Simple
 Name:               graph-wrapper
 Version:            0.2.4.3
-Maintainer:         Max Bolingbroke <batterseapower@hotmail.com>
-Homepage:           http://www.github.com/batterseapower/graph-wrapper
+Maintainer:         Max Bolingbroke <batterseapower@hotmail.com>, Sönke Hahn <soenkehahn@gmail.com>
+Homepage:           https://github.com/soenkehahn/graph-wrapper
 License:            BSD3
 License-File:       LICENSE
 Author:             Max Bolingbroke
 Synopsis:           A wrapper around the standard Data.Graph with a less awkward interface
 Category:           Data Structures, Graphs
+
+source-repository head
+    type: git
+    location: https://github.com/soenkehahn/graph-wrapper
 
 Library
     Exposed-Modules:    Data.Graph.Wrapper


### PR DESCRIPTION
This PR:
- Adds a travis file,
- adds support for `ghc-7.10`,
- changes the maintainer in the cabal file to me,
- changes the url to point to my github repo,
- adds a repo section pointing to my github repo and
- bumps the version on the patch-level.